### PR TITLE
Feature update pg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_script:
   - "export SEQ_PG_USER=postgres"
   - "export SEQ_PG_PW=postgres"
   - 'if [ "$SEQ_VERSION" ]; then npm install sequelize@^$SEQ_VERSION.0.0; fi'
+  - 'if [ "$SEQ_VERSION" == "3" ]; then npm install pg@6; npm install pg-native@1.10.0; fi'
+  - 'if [ "$SEQ_VERSION" == "2" ]; then npm install pg@6; npm install pg-native@1.10.0; fi'
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sequelize-hierarchy.js
 
+(this is fork with few fixes/patches)
+
 # Nested hierarchies for Sequelize
 
 [![NPM version](https://img.shields.io/npm/v/sequelize-hierarchy.svg)](https://www.npmjs.com/package/sequelize-hierarchy)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-hierarchy",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Nested hierarchies for Sequelize",
   "main": "./lib/",
   "author": {
@@ -22,12 +22,12 @@
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
     "sequelize": "^4.3.2",
-    "mysql": "~2.10.1",
+    "mysql": "^2.15.0",
     "mysql2": "^1.2.0",
     "sqlite3": "^3.1.4",
-    "pg": "^6.1.0",
+    "pg": "^7.4.0",
     "pg-hstore": "^2.3.2",
-    "pg-native": "^1.10.0",
+    "pg-native": "^2.2.0",
     "tedious": "^1.14.0",
     "jshint": "^2.9.5",
     "istanbul": "^0.4.5",


### PR DESCRIPTION
Old Sequelize v2 and v3 is not compatible with new pg@7, so you should use old versions (pg@6, pg-native@1).

Recent Sequelize@4 is ok with pg@7 and pg-native@2